### PR TITLE
Implement initial AI-powered tagging pass

### DIFF
--- a/app/Console/Commands/TestTagCreation.php
+++ b/app/Console/Commands/TestTagCreation.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Tag;
+use Illuminate\Console\Command;
+
+class TestTagCreation extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:test-tag-creation';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Tests tag creation prompts (will result in small charge)';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        print_r(Tag::generateAndSave(
+            "Class: ENG201 (Section This Totally Is Real) - Samuel Johnson
+            Firstly: show and tell exist on a spectrum. You shouldn't always tell either - the rule of thumb is just that people are more likely to tell too much and not show enough, and as such the common writing advice exists.
+            Secondly, when you get down to it, horror as a genre is really fundamentally about the modulation of constant tension. In that way, it's a little bit similar to the thriller, but quite different from the story structures more common in sff (though, obviously, there's a lot of crosspollination), so a lot of advice geared towards other genre fic doesn't work well when applied to it.
+            Finally: an analysis commonly attributed to Orson Scott Card (obligatory yeah, he's kind of an awful person, but his writing advice has massively impacted the gestalt of writing advice in general) but honestly also expressed by a number of different authors in various ways is a fairly specific categorization system regarding modulating horror, from strongest (in the sense of best carrying narrative) emotion to weakest - you have dread, the tension of waiting for something unknown, that he considers the strongest form of fear and the best for novelist purposes; terror, the revelation of the unknown, that freezes you in place and engages the fight/flight response; and horror, the feeling of the aftereffects of the now known threat (nausea, pity for yourself and others, etc.). It's the reaction to a horrifying event, which he identifies as the weakest due to it easily becoming numb upon repeated experience.
+        Now, this is a pretty common analysis, as I said, and the initial impression (and common writing advice) is that you hold the actual visage or actions of the horror-inducing thing off for as long as possible to stretch out that dread. However - and I think IT is an especially good case study for this - there's other ways to invoke dread than the simple knowledge of the existence of the monster. As long as something is hanging over the story, something is looming, you still have that crucial ingredient. It's also possible to make do without any of that at all - the dread->terror->horror escalation and deescalation is one way to invoke tension and keep a story interesting, but it's definitely not the only way. Marble Hornets having a mystery component definitely is a big part of why it works there; it's the Scooby Doo formula."
+        )); // Note sourced from myself on discord
+
+        print_r(Tag::index());
+    }
+}

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace App\Models;
+
+use App\Helpers\OpenAIHelpers;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use UnexpectedValueException;
+
+class Tag
+{
+    public int $id;
+    public string $content;
+
+    /**
+     * @throws UnexpectedValueException if API prompts fail.
+     */
+    public static function generateAndSave(/* Note $note */ string $note_content): array
+    {
+        $response = OpenAIHelpers::submitCompletion(
+            "You will be provided with a document delimited by three brackets. \
+                Your task is to select excerpts representative of the core ideas of the text. \
+                Ensure that all excerpts contain all relevant context needed to interpret them - in other words, \
+                don't extract small snippets that are missing important context. Additionally, any passage describing the purpose of the text, \
+                such as mention of workplace, educational class, or medium, should be stored only in a separate excerpt,
+                which must begin with the text 'MEDIUM:'. \
+                Provide output in JSON format as follows:\n \
+                [{'excerpt': '...'},\n \
+                ...\n \
+                {'excerpt': '...'}]",
+            "{{{" . $note_content . "}}}"
+        );
+
+        // Guard this against error return value later
+        $json = json_decode($response);
+        if (empty($json)) {
+            throw new UnexpectedValueException("Empty JSON object was returned from API while generating excerpts.");
+        }
+
+        $excerpts = $json->choices[0]->message->content;
+
+        $response = OpenAIHelpers::submitCompletion(
+            "You will be provided with a series of excerpts from a text formatted in JSON. \
+                Your task is to create a list of single-word tags describing the core themes of both all of the excerpts and individual excerpts, \
+                with preference given to the tags describing all of the excerpts. This list of tags should be equal in length to the number of \
+                excerpts given. If an excerpt contains the text 'MEDIUM:', its purpose is to describe the purpose of the text, \
+                and a special tag should be made for it containing the name of the medium, such as a class number or workplace. \
+                Provide output in array format as follows:\n \
+                [<tag>, \
+                ..., \
+                <tag>]",
+                $excerpts
+        );
+
+        $json = json_decode($response);
+        if (empty($json)) {
+            throw new UnexpectedValueException("Empty JSON object returned from API while generating tags.");
+        }
+
+        $tags = explode(",", $json->choices[0]->message->content);
+        $indices = [];
+        foreach ($tags as $content) {
+            $indices[] = self::save($content);
+        }
+
+        return $indices;
+    }
+
+    private static function save(/* Note $note, */ string $content): int
+    {
+        $existing_tags = self::getByContent($content);
+        if (!empty($existing_tags)) {
+            // insert_into_notes_to_tags(note, tag)
+        }
+
+        //  submitCompletion("If tags similar, combine and return text");
+        //
+        //  decodeIntoArray(text)
+
+        $params = ['content' => $content];
+
+        $sql = "
+            INSERT INTO tags (created_at, content)
+            VALUES (timezone('utc', now()), :content);
+        ";
+
+        try {
+            DB::insert($sql, $params);
+            $id = DB::getPdo()->lastInsertId();
+        } catch (QueryException $err) {
+            $msg = __METHOD__ . ': ' . $err->getMessage() . PHP_EOL . $err->getTraceAsString();
+            Log::err($msg);
+
+            throw $err;
+        }
+
+        // insert_into_note_to_tag(note, tag)
+
+        return $id;
+    }
+
+    private static function asObjectArray(array &$results): array
+    {
+        $res = [];
+        foreach ($results as $value) {
+            $obj = new self;
+            foreach ($value as $key => $val) {
+                $obj->{$key} = $val;
+            }
+
+            $res[] = $obj;
+        }
+
+        return $res;
+    }
+
+    public static function index(): array
+    {
+        $sql = "SELECT * FROM tags;";
+
+        try {
+            $res = DB::select($sql, []);
+            if (empty($res)) {
+                $res = [];
+            }
+        } catch (QueryException $err) {
+            $msg = __METHOD__ . ": " . $err->getMessage() . PHP_EOL . $err->getTraceAsString();
+            Log::error($msg);
+
+            throw $err;
+        }
+
+        return static::asObjectArray($res);
+    }
+
+    public static function getByContent(string $content): array
+    {
+        $params = ['content' => $content];
+        $sql = "SELECT * FROM tags WHERE content = :content;";
+
+        try {
+            $res = DB::select($sql, $params);
+            if (empty($res)) {
+                $res = [];
+            }
+        } catch (QueryException $err) {
+            $msg = __METHOD__ . ": " . $err->getMessage() . PHP_EOL . $err->getTraceAsString();
+            Log::error($msg);
+
+            throw $err;
+        }
+
+        return static::asObjectArray($res);
+    }
+
+    public static function getById(int $id)
+    {
+        $params = ['id' => $id];
+        $sql = "SELECT * FROM tags WHERE id = :id;";
+
+        try {
+            $res = DB::select($sql, $params);
+            if (empty($res)) {
+                $res = [];
+            }
+        } catch (QueryException $err) {
+            $msg = __METHOD__ . ": " . $err->getMessage() . PHP_EOL . $err->getTraceAsString();
+            Log::error($msg);
+
+            throw $err;
+        }
+
+        return static::asObjectArray($res);
+    }
+}

--- a/database/migrations/2025_01_27_191715_create_tags_table.php
+++ b/database/migrations/2025_01_27_191715_create_tags_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('tags', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+            $table->string('content');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('tags');
+    }
+};

--- a/database/migrations/2025_02_02_012118_create_notes_to_tags_table.php
+++ b/database/migrations/2025_02_02_012118_create_notes_to_tags_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('notes_to_tags', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+            $table->integer('tag')->unsigned()->index();
+            $table->integer('note')->unsigned()->index();
+
+            $table->foreign('tag')->references('id')->on('tags')->onDelete('cascade');
+        //  $table->foreign('note')->references('id')->on('notes')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('notes_to_tags');
+    }
+};


### PR DESCRIPTION
The current strategy is a two-phase pass; the first identifies key excerpts from the text, and the second condenses that context down individual tags. Additionally, tags relevant to identifying an associated class or purpose should be identified.

A later second pass should be implemented to remove tags already similar to tags currently existing in the DB for a given user, so that's on my to-do, as well as setting up a parse-by-chunks system for long notes to get around token limit issues (presumably we can do it iteratively - parse chunk one, add excerpts, parse chunk two, add excerpts, etc.; then batch parse excerpts).